### PR TITLE
Implement CLI and backend server with user authentication

### DIFF
--- a/cmd/cli/commands/whoami.go
+++ b/cmd/cli/commands/whoami.go
@@ -1,0 +1,102 @@
+package commands
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+
+	"github.com/spf13/cobra"
+)
+
+type whoamiResponse struct {
+	Username string `json:"username"`
+	Role     string `json:"role"`
+}
+
+// whoamiCmd represents the whoami command
+var whoamiCmd = &cobra.Command{
+	Use:   "whoami",
+	Short: "Display current user information",
+	Long: `Shows details about the currently authenticated user, including username and role.
+
+Example:
+  tunnelR whoami
+
+This command uses the saved authentication token from previous login.`,
+	Run: func(_ *cobra.Command, _ []string) {
+		// Load config to get token and server
+		config, err := loadConfig()
+		if err != nil {
+			fmt.Println("Error loading config:", err)
+			fmt.Println("Please login first using the login command")
+			os.Exit(1)
+		}
+
+		if config.Token == "" {
+			fmt.Println("No authentication token found. Please login first using the login command")
+			os.Exit(1)
+		}
+
+		server := config.Server
+		if server == "" {
+			fmt.Println("No server configured. Please connect to server first")
+			os.Exit(1)
+		}
+
+		// Create HTTP request
+		url := fmt.Sprintf("http://%s/api/whoami", server)
+		req, err := http.NewRequest("GET", url, nil)
+		if err != nil {
+			fmt.Println("Error creating request:", err)
+			os.Exit(1)
+		}
+
+		// Add auth token to header
+		req.Header.Set("Authorization", "Bearer "+config.Token)
+
+		// Make the request
+		client := &http.Client{}
+		resp, err := client.Do(req)
+		if err != nil {
+			fmt.Println("Error sending request:", err)
+			os.Exit(1)
+		}
+		defer func() {
+			if err := resp.Body.Close(); err != nil {
+				fmt.Println("Error closing response body:", err)
+			}
+		}()
+
+		// Handle response
+		switch resp.StatusCode {
+		case http.StatusOK:
+			var userInfo whoamiResponse
+			if err := json.NewDecoder(resp.Body).Decode(&userInfo); err != nil {
+				fmt.Println("Error parsing response:", err)
+				os.Exit(1)
+			}
+
+			fmt.Println("Current user information:")
+			fmt.Printf("Username: %s\n", userInfo.Username)
+			fmt.Printf("Role: %s\n", userInfo.Role)
+
+		case http.StatusUnauthorized:
+			fmt.Println("Error: Your session has expired or is invalid. Please login again.")
+			os.Exit(1)
+
+		default:
+			fmt.Printf("Error: Unexpected response (%d)\n", resp.StatusCode)
+			body, _ := io.ReadAll(resp.Body)
+			if len(body) > 0 {
+				fmt.Println(string(body))
+			}
+			os.Exit(1)
+		}
+	},
+}
+
+func init() {
+	RootCmd.AddCommand(whoamiCmd)
+}

--- a/internal/api/presentation/handlers/user.go
+++ b/internal/api/presentation/handlers/user.go
@@ -122,19 +122,33 @@ func (h *UserHandler) Login(w http.ResponseWriter, r *http.Request) {
 
 // GetUserInfo retrieves the current user's information from the JWT token
 func (h *UserHandler) GetUserInfo(w http.ResponseWriter, r *http.Request) {
-	claims, ok := r.Context().Value(appctx.UserClaimsKey).(*jwt.MapClaims)
-	if !ok || claims == nil {
+	// Get claims from context and handle both pointer and value types
+	var normalizedClaims map[string]interface{}
+	ctxValue := r.Context().Value(appctx.UserClaimsKey)
+
+	switch v := ctxValue.(type) {
+	case *jwt.MapClaims:
+		if v == nil {
+			http.Error(w, "Unauthorized", http.StatusUnauthorized)
+			return
+		}
+		normalizedClaims = *v
+	case jwt.MapClaims:
+		normalizedClaims = v
+	default:
 		http.Error(w, "Unauthorized", http.StatusUnauthorized)
 		return
 	}
 
-	username, ok := (*claims)["username"].(string)
+	// Extract username
+	username, ok := normalizedClaims["username"].(string)
 	if !ok {
 		http.Error(w, "Invalid token claims", http.StatusUnauthorized)
 		return
 	}
 
-	role, ok := (*claims)["role"].(string)
+	// Extract role
+	role, ok := normalizedClaims["role"].(string)
 	if !ok {
 		http.Error(w, "Invalid token claims", http.StatusUnauthorized)
 		return

--- a/internal/api/presentation/handlers/user.go
+++ b/internal/api/presentation/handlers/user.go
@@ -8,8 +8,10 @@ import (
 	"net/http"
 	"strings"
 
+	appctx "github.com/codaxa/tunnelR.git/internal/api/app/context"
 	"github.com/codaxa/tunnelR.git/internal/api/app/service"
 	"github.com/codaxa/tunnelR.git/internal/api/core/model"
+	"github.com/golang-jwt/jwt"
 )
 
 // AuthServicer defines the authentication service interface
@@ -112,6 +114,42 @@ func (h *UserHandler) Login(w http.ResponseWriter, r *http.Request) {
 	resp := tokenResponse{Token: token}
 	w.Header().Set("Content-Type", "application/json")
 	if err := json.NewEncoder(w).Encode(resp); err != nil {
+		log.Printf("ERROR encoding response: %v", err)
+		http.Error(w, "Failed to encode response", http.StatusInternalServerError)
+		return
+	}
+}
+
+// GetUserInfo retrieves the current user's information from the JWT token
+func (h *UserHandler) GetUserInfo(w http.ResponseWriter, r *http.Request) {
+	claims, ok := r.Context().Value(appctx.UserClaimsKey).(*jwt.MapClaims)
+	if !ok || claims == nil {
+		http.Error(w, "Unauthorized", http.StatusUnauthorized)
+		return
+	}
+
+	username, ok := (*claims)["username"].(string)
+	if !ok {
+		http.Error(w, "Invalid token claims", http.StatusUnauthorized)
+		return
+	}
+
+	role, ok := (*claims)["role"].(string)
+	if !ok {
+		http.Error(w, "Invalid token claims", http.StatusUnauthorized)
+		return
+	}
+
+	response := struct {
+		Username string `json:"username"`
+		Role     string `json:"role"`
+	}{
+		Username: username,
+		Role:     role,
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	if err := json.NewEncoder(w).Encode(response); err != nil {
 		log.Printf("ERROR encoding response: %v", err)
 		http.Error(w, "Failed to encode response", http.StatusInternalServerError)
 		return

--- a/internal/api/presentation/router.go
+++ b/internal/api/presentation/router.go
@@ -19,17 +19,22 @@ func NewRouter(authService *service.AuthService) *chi.Mux {
 	router.Get("/healthz", handlers.HealthHandler)
 	router.Get("/version", handlers.VersionHandler)
 
-	router.Post("/api/login", userHandler.Login)
-
-	// API authenticated routes
-	// router.Route("/api", func(r chi.Router) {
-	// 	r.Use(authMiddleware.Authenticate)
-	// })
-
-	// API admin authenticated routes
+	// API routes
 	router.Route("/api", func(r chi.Router) {
-		r.Use(authMiddleware.AdminAuthenticate)
-		r.Post("/register", userHandler.Register)
+		// Public API endpoints
+		r.Post("/login", userHandler.Login)
+
+		// Authenticated user routes
+		r.Group(func(r chi.Router) {
+			r.Use(authMiddleware.Authenticate)
+			r.Get("/whoami", userHandler.GetUserInfo)
+		})
+
+		// Admin-only routes
+		r.Group(func(r chi.Router) {
+			r.Use(authMiddleware.AdminAuthenticate)
+			r.Post("/register", userHandler.Register)
+		})
 	})
 
 	return router


### PR DESCRIPTION
Introduce a CLI skeleton and backend server with health and version endpoints. Enhance user authentication features, including login and registration, while managing database connections and configurations. Update Taskfile for streamlined CLI operations and improve error handling throughout the application.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a CLI command to show the current authenticated user and role.
  * Added an authenticated API endpoint GET /api/whoami that returns username and role.

* **Refactor**
  * Consolidated API routes under /api with public, authenticated, and admin-only groups.
  * Moved login to /api/login (public).
  * Made registration an admin-only endpoint at /api/register.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->